### PR TITLE
Lower php version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "php": "~7.2"
+        "php": "~7.1"
     },
     "require-dev": {
         "phpstan/phpstan": ">=0.10"


### PR DESCRIPTION
Hello, me again!

PHPStan requires php 7.1, I am using that version and I guest you are not using any of the 7.2 features.

Do you think you could lower the requirement? I guess it would be easier for people to adopt your library if it has the same requirements as PHPStan.